### PR TITLE
Restrict base lower bound to prevent build plans on GHC <7.8

### DIFF
--- a/hpath.cabal
+++ b/hpath.cabal
@@ -35,7 +35,8 @@ library
                      System.Posix.FD,
                      System.Posix.FilePath
   other-modules:     HPath.Internal
-  build-depends:     base >= 4.2 && <5
+  other-extensions:  PatternSynonyms
+  build-depends:     base >= 4.7 && <5
                    , IfElse
                    , bytestring >= 0.9.2.0
                    , deepseq


### PR DESCRIPTION
Also add PatternSynonyms to OtherExtensions