### PR TITLE
Make compatible with streamly 0.8.0

### DIFF
--- a/hpath-directory/src/System/Posix/RawFilePath/Directory.hs
+++ b/hpath-directory/src/System/Posix/RawFilePath/Directory.hs
@@ -147,8 +147,13 @@ import qualified Streamly.FileSystem.Handle    as FH
 import qualified Streamly.Internal.Data.Unfold as SU
 import qualified Streamly.Internal.FileSystem.Handle
                                                as IFH
+#if MIN_VERSION_streamly(0,8,0)
+import qualified Streamly.Internal.Data.Array.Stream.Foreign
+                                               as AS
+#else
 import qualified Streamly.Internal.Memory.ArrayStream
                                                as AS
+#endif
 import qualified Streamly.Prelude              as S
 import qualified System.IO                     as SIO
 import           System.IO.Error                ( catchIOError


### PR DESCRIPTION
`hpath-directory` as-is doesn't build with streamly version 0.8.0 because some module paths changed. The latest streamly version it built with was 0.7.3.

I expect that you want to at least change formatting on this PR and/or commit it yourself. I just wanted to give you this to potentially save a bit of effort. Furthermore, I only changed hpath-directory; the rest of the packages in this repo either already build with streamly 0.8.0 or happen to not be in the dependency tree of my `pastebin-haskell`. :)

**DO NOTE**: Please double-check that the substituted module is semantically equivalent. I have no experience whatsoever with these libraries, so I just "did something". Hopefully submitting this PR helps you. :)